### PR TITLE
Includes CACHE_REDIS_SSLfor SSL connection to redis server

### DIFF
--- a/src/flask_caching/backends/rediscache.py
+++ b/src/flask_caching/backends/rediscache.py
@@ -92,6 +92,10 @@ class RedisCache(BaseCache):
         db_number = config.get("CACHE_REDIS_DB")
         if db_number:
             kwargs["db"] = db_number
+            
+        ssl = config.get("CACHE_REDIS_SSL")
+        if ssl:
+            kwargs["ssl"] = ssl
 
         redis_url = config.get("CACHE_REDIS_URL")
         if redis_url:


### PR DESCRIPTION
Included option to pass "CACHE_REDIS_SSL" through cache configurations to use "ssl=True/False" argument from redis backend.